### PR TITLE
Sets chrome and vision levels darker than preview background

### DIFF
--- a/src/components/chrome/index.jsx
+++ b/src/components/chrome/index.jsx
@@ -25,17 +25,12 @@ class Chrome extends Component {
       containerBackground = modifier(background);
     }
 
-    const lums = chroma(containerBackground).luminance();
-    const isDark = lums <= 0.5;
-
     return (
       <span
         className={style.chrome}
         style={{
           WebkitAppRegion: 'drag',
-          backgroundColor: isDark
-            ? chroma(containerBackground).darken(0.3)
-            : chroma(containerBackground).brighten(0.3),
+          backgroundColor: chroma(containerBackground).darken(1.5),
         }}/>
     );
   }

--- a/src/components/colorBlindOptions/index.jsx
+++ b/src/components/colorBlindOptions/index.jsx
@@ -50,8 +50,10 @@ class ColorBlindOptions extends Component {
       const modifier = blind[setting];
       containerBackground = modifier(background)
     }
+    const previewColor = containerBackground;
 
     containerBackground = chroma(containerBackground).darken(1);
+    const secondRowColor = chroma(containerBackground).brighten(0.2);
 
     const lums = chroma(containerBackground).luminance();
     const isDark = lums <= 0.5;
@@ -77,6 +79,10 @@ class ColorBlindOptions extends Component {
                     this.props.setColorBlind(e.target.value, blindSettings[e.target.value] ? blindSettings[e.target.value][0] : null)
                   }}/>
                 <span>{type}</span>
+                <Triangle
+                  className={style.triangle}
+                  fill={type === 'common' ? previewColor : secondRowColor}
+                  />
               </label>
             );
           })}
@@ -85,7 +91,7 @@ class ColorBlindOptions extends Component {
           <div
             className={style.blindTypes}
             style={{
-              backgroundColor: chroma(containerBackground).brighten(0.2),
+              backgroundColor: secondRowColor,
             }}>
             {blindSettings[blindness].map((type) => {
               return (
@@ -101,12 +107,48 @@ class ColorBlindOptions extends Component {
                       this.props.setColorBlind(blindness, e.target.value);
                     }}/>
                   <span>{type}</span>
+                  <Triangle
+                    className={style.triangle}
+                    fill={previewColor}
+                    />
                 </label>
               );
             })}
           </div>
         )}
       </div>
+    );
+  }
+}
+
+class Triangle extends Component {
+  static propTypes = {
+    fill: PropTypes.string,
+    className: PropTypes.string,
+  }
+
+  static defaultProps = {
+    fill: '#ffffff',
+  }
+
+  render() {
+    const {
+      fill,
+      className,
+    } = this.props;
+
+    return (
+      <svg
+        className={className}
+        width='6'
+        height='4'
+        viewBox='0 0 6 4'
+        xmlns='http://www.w3.org/2000/svg'>
+        <path
+          fill={fill}
+          d='M3 0l3 4H0'
+          fill-rule='evenodd'/>
+      </svg>
     );
   }
 }

--- a/src/components/colorBlindOptions/index.jsx
+++ b/src/components/colorBlindOptions/index.jsx
@@ -53,7 +53,7 @@ class ColorBlindOptions extends Component {
     const previewColor = containerBackground;
 
     containerBackground = chroma(containerBackground).darken(1);
-    const secondRowColor = chroma(containerBackground).brighten(0.2);
+    const secondRowColor = chroma(containerBackground).brighten(0.5);
 
     const lums = chroma(containerBackground).luminance();
     const isDark = lums <= 0.5;

--- a/src/components/colorBlindOptions/index.jsx
+++ b/src/components/colorBlindOptions/index.jsx
@@ -51,12 +51,10 @@ class ColorBlindOptions extends Component {
       containerBackground = modifier(background)
     }
 
+    containerBackground = chroma(containerBackground).darken(1);
+
     const lums = chroma(containerBackground).luminance();
     const isDark = lums <= 0.5;
-
-    containerBackground = isDark
-      ? chroma(containerBackground).darken(0.15)
-      : chroma(containerBackground).brighten(0.15);
 
     return (
       <div
@@ -87,9 +85,7 @@ class ColorBlindOptions extends Component {
           <div
             className={style.blindTypes}
             style={{
-              backgroundColor: isDark
-                ? chroma(containerBackground).brighten(0.07)
-                : chroma(containerBackground).darken(0.07),
+              backgroundColor: chroma(containerBackground).brighten(0.2),
             }}>
             {blindSettings[blindness].map((type) => {
               return (

--- a/src/components/colorBlindOptions/style.css
+++ b/src/components/colorBlindOptions/style.css
@@ -14,6 +14,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
 
   & span {
     opacity: 0.5;
@@ -26,6 +27,20 @@
       & + span {
         opacity: 1;
       }
+
+      & ~ .triangle {
+        display: block;
+      }
     }
   }
+}
+
+.triangle {
+  position: absolute;
+  bottom: -2px;
+  left: 50%;
+  margin-left: -5px;
+  display: none;
+  width: 10px;
+  height: 10px;
 }

--- a/src/components/colorBlindOptions/style.css
+++ b/src/components/colorBlindOptions/style.css
@@ -10,7 +10,7 @@
   flex-shrink: 1;
   font-size: 12px;
   line-height: 15px;
-  height: 30px;
+  height: 40px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/controls/index.jsx
+++ b/src/components/controls/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import chroma, { mix } from 'chroma-js';
+import chroma from 'chroma-js';
 import blind from 'color-blind';
 import {
   setForeground,
@@ -40,7 +40,7 @@ class Controls extends Component {
       <div
         className={style.container}
         style={{
-          backgroundColor: mix('#1a1a1a', containerBackground, 0.2),
+          backgroundColor: chroma(containerBackground).darken(3),
         }}>
         <label className={style.inputLabel}>
           <b>Foreground</b>


### PR DESCRIPTION
The chrome and vision levels are dynamically set darker than whatever the assigned background preview color is. The controls section is changed to use a darker variant of the preview color rather than being mixed gray.