### PR TITLE
Font size accommodations for smaller screen sizes

### DIFF
--- a/src/views/results/styles.module.css
+++ b/src/views/results/styles.module.css
@@ -76,3 +76,15 @@
   margin: 0;
   text-align: center;
 }
+
+@media (max-width: 500px) {
+  .perceptionLabel {
+    font-size: 12px;
+    line-height: 15px;
+  }
+
+  .contrastRating {
+    font-size: 24px;
+    line-height: 30px;
+  }
+}


### PR DESCRIPTION
When the viewport is up to 500px wide, the result label and rating type is made slightly smaller.